### PR TITLE
Contact plugin should not be cached

### DIFF
--- a/cmsplugin_contact_plus/cms_plugins.py
+++ b/cmsplugin_contact_plus/cms_plugins.py
@@ -14,6 +14,7 @@ class CMSContactPlusPlugin(CMSPluginBase):
     inlines = [ExtraFieldInline, ]
     name = _('Contact Form')
     render_template = "cmsplugin_contact_plus/contact.html"
+    cache = False
 
     def render(self, context, instance, placeholder):
         request = context['request']


### PR DESCRIPTION
New in django-cms 3.0c, all plugins are cached through django cache. If the contact form is cached, the "thank you" message will not be displayed and the visitor will get no feedback whether or not his message has been sent.

This will force the contact form to not be cached.
