### PR TITLE
Fix relative import for Python 3

### DIFF
--- a/cmsplugin_contact_plus/models.py
+++ b/cmsplugin_contact_plus/models.py
@@ -16,7 +16,7 @@ try:
 except:
     DEFAULT_FROM_EMAIL_ADDRESS = ''
 
-import utils
+from cmsplugin_contact_plus import utils
 
 
 localdata = threading.local()


### PR DESCRIPTION
When working with Python 3.4, I came across this relative import problem that prevented Django from booting up the server. This should fix it.