### PR TITLE
Fixes 2 Django 1.8 migration issues

### DIFF
--- a/cmsplugin_contact_plus/migrations/0001_initial.py
+++ b/cmsplugin_contact_plus/migrations/0001_initial.py
@@ -6,6 +6,8 @@ import django.db.models.deletion
 import cmsplugin_contact_plus.models
 import jsonfield.fields
 
+from cmsplugin_contact_plus.models import FIELD_TYPE
+
 
 class Migration(migrations.Migration):
 
@@ -54,7 +56,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('inline_ordering_position', models.IntegerField(null=True, blank=True)),
                 ('label', models.CharField(max_length=100, verbose_name='Label')),
-                ('fieldType', models.CharField(max_length=100, choices=[(b'CharField', b'CharField'), (b'BooleanField', b'BooleanField'), (b'EmailField', b'EmailField'), (b'DecimalField', b'DecimalField'), (b'FloatField', b'FloatField'), (b'IntegerField', b'IntegerField'), (b'IPAddressField', b'IPAddressField'), (b'auto_Textarea', b'CharField as Textarea'), (b'auto_hidden_input', b'CharField as HiddenInput'), (b'auto_referral_page', b'Referral page as HiddenInput'), (b'auto_GET_parameter', b'GET parameter as HiddenInput')])),
+                ('fieldType', models.CharField(max_length=100, choices=FIELD_TYPE)),
                 ('initial', models.CharField(max_length=250, null=True, verbose_name='Inital Value', blank=True)),
                 ('required', models.BooleanField(default=True, verbose_name='Mandatory field')),
                 ('widget', models.CharField(help_text='Will be ignored in the current version.', max_length=250, null=True, verbose_name='Widget', blank=True)),

--- a/cmsplugin_contact_plus/migrations/0002_auto_20151013_1157.py
+++ b/cmsplugin_contact_plus/migrations/0002_auto_20151013_1157.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_contact_plus', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contactplus',
+            name='recipient_email',
+            field=models.EmailField(default=b'', max_length=254, verbose_name='Email of recipients'),
+        ),
+    ]

--- a/cmsplugin_contact_plus/models.py
+++ b/cmsplugin_contact_plus/models.py
@@ -41,7 +41,8 @@ class ContactPlus(CMSPlugin):
             verbose_name=_("Email subject"),
             default=get_current_site)
     recipient_email = models.EmailField(_("Email of recipients"), 
-            default=DEFAULT_FROM_EMAIL_ADDRESS)
+            default=DEFAULT_FROM_EMAIL_ADDRESS,
+            max_length=254)
     collect_records = models.BooleanField(_('Collect Records'), 
             default=True, 
             help_text=_("If active, all records for this Form will be stored in the Database."))


### PR DESCRIPTION
On django 1.8 projects, a new migration is always created. 

One reason is that `choices` on `fieldType` regularly changes. To fix that, I made the initial migration import and use `FIELD_TYPE` dynamically so that it won't create a new migration every time we add a field type. And since we added a recaptcha field only if recaptcha is installed, some users could have gotten a new migration, while others might not have.

The other reason is that django changed the default `max_length` on `EmailField`s from 75 to 254 in version 1.8. I simply added the migration which django would automatically create. But since some users could be using django 1.7, they would then get a new migration to change it back to 75. So I also set `max_length` on the `recipient_email` field so that doesn't happen.