### PR TITLE
Ability to customise form class used from the settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ CMSPLUGIN_CONTACT_FORM_VALIDATORS = [
   'myproject.utils.validators.phone_number_validator',
 ]
 
+### ``CMSPLUGIN_CONTACT_FORMCLASS``
+
+To customize the form class, specify ``CMSPLUGIN_CONTACT_FORM_FORMCLASS`` in your projects settings.
+Its value should be a string with the python path to a subclass of ``cmsplugin_contact_plus.forms.ContactFormPlus``
+where you can extends the base behaviour.
+
 ### reCAPTCHA
 
 To make the reCAPTCHA field type available to your users, add `'captcha'` to your `INSTALLED_APPS` and define your `RECAPTCHA_PUBLIC_KEY` and `RECAPTCHA_PRIVATE_KEY` as described in [django-recaptcha's README](https://github.com/praekelt/django-recaptcha/blob/develop/README.rst). A single reCAPTCHA instance per page is supported.

--- a/cmsplugin_contact_plus/cms_plugins.py
+++ b/cmsplugin_contact_plus/cms_plugins.py
@@ -31,7 +31,7 @@ class CMSContactPlusPlugin(CMSPluginBase):
 
     def get_form_class(self):
         try:
-            form_path = settings.CMS_CONTACT_PLUS_FORM
+            form_path = settings.CMSPLUGIN_CONTACT_FORMCLASS
         except AttributeError:
             return ContactFormPlus
         else:

--- a/cmsplugin_contact_plus/cms_plugins.py
+++ b/cmsplugin_contact_plus/cms_plugins.py
@@ -45,8 +45,8 @@ class CMSContactPlusPlugin(CMSPluginBase):
         if instance and instance.template:
             self.render_template = instance.template
 
+        FormClass = self.get_form_class()
         if request.method == "POST" and "contact_plus_form_" + str(instance.id) in request.POST.keys():
-            FormClass = self.get_form_class()
             form = FormClass(contactFormInstance=instance,
                     request=request, 
                     data=request.POST, 
@@ -70,7 +70,7 @@ class CMSContactPlusPlugin(CMSPluginBase):
                 })
 
         else:
-            form = ContactFormPlus(contactFormInstance=instance, request=request)
+            form = FormClass(contactFormInstance=instance, request=request)
             context.update({
                     'contact': instance,
                     'form': form,


### PR DESCRIPTION
Needed that to be able to style my "contact us" form with Bootstrap 3 using a [crispy form](http://django-crispy-forms.readthedocs.io/en/latest/index.html) helper. 

**settings.py**

``` python
CMSPLUGIN_CONTACT_FORMCLASS = 'myapp.forms.MyContactUsForm'
```

**forms.py python 3**

``` python
from crispy_forms.helper import FormHelper
from crispy_forms.layout import Submit
from cmsplugin_contact_plus.forms import ContactFormPlus

class MyContactUsForm(ContactFormPlus):

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.helper = FormHelper()
        self.helper.form_tag = False
```

**contact.html**

``` django
{% load crispy_forms_tags %}
{% if form %}
  <form {% if form.is_multipart %}enctype="multipart/form-data"{% endif %} method="POST" action="" class="form">
    {% crispy form %}
    <div class="text-right">
      <input type="submit" class="btn btn-primary" name="contact_plus_form_{{ contact.id }}" {% if contact.submit %} value="{{ contact.submit }}"{% endif %} />
    </div>
  </form>
{% else %}
  {{ contact.thanks|safe }}
{% endif %}
```
