### PR TITLE
Don't localize the id

### DIFF
--- a/cmsplugin_contact_plus/templates/cmsplugin_contact_plus/contact.html
+++ b/cmsplugin_contact_plus/templates/cmsplugin_contact_plus/contact.html
@@ -1,3 +1,5 @@
+{% load l10n %}
+
 {% if form %}
     {% if form.is_multipart %}
         <form enctype="multipart/form-data" method="POST" action="">
@@ -6,7 +8,7 @@
     {% endif %}
 	{% csrf_token %}
 		{{ form.as_p }}
-		<input type="submit" name="contact_plus_form_{{ contact.id }}" {% if contact.submit %} value="{{ contact.submit }}"{% endif %} />
+		<input type="submit" name="contact_plus_form_{{ contact.id|unlocalize }}" {% if contact.submit %} value="{{ contact.submit }}"{% endif %} />
 	</form>
 {% else %}
 	{{ contact.thanks|safe }}


### PR DESCRIPTION
We must prevent Django from localizing the id, else the form may not be sent if
``L10N`` causes a thousands separator to be used.