### PR TITLE
Add input placeholders.

### DIFF
--- a/cmsplugin_contact_plus/admin.py
+++ b/cmsplugin_contact_plus/admin.py
@@ -8,7 +8,7 @@ from .actions import export_as_csv_action
 
 class ExtraFieldInline(SortableTabularInline):
     model = ExtraField
-    fields = ('label', 'fieldType', 'initial', 'required')
+    fields = ('label', 'fieldType', 'initial', 'placeholder', 'required')
 
 
 class ContactFormPlusAdmin(NonSortableParentAdmin):

--- a/cmsplugin_contact_plus/forms.py
+++ b/cmsplugin_contact_plus/forms.py
@@ -22,8 +22,9 @@ class ContactFormPlus(forms.Form):
             for extraField in contactFormInstance.extrafield_set.all():
                 if extraField.fieldType == 'CharField':
                     self.fields[slugify(extraField.label)] = forms.CharField(label=extraField.label,
+                            initial=extraField.initial,
                             widget=forms.TextInput(
-                                attrs={'placeholder': extraField.initial}
+                                attrs={'placeholder': extraField.placeholder}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'BooleanField':
@@ -32,20 +33,23 @@ class ContactFormPlus(forms.Form):
                             required=extraField.required)
                 elif extraField.fieldType == 'EmailField':
                     self.fields[slugify(extraField.label)] = forms.EmailField(label=extraField.label,
+                            initial=extraField.initial,
                             widget=forms.TextInput(
-                                attrs={'placeholder': extraField.initial}
+                                attrs={'placeholder': extraField.placeholder}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'DecimalField':
                     self.fields[slugify(extraField.label)] = forms.DecimalField(label=extraField.label,
+                            initial=extraField.initial,
                             widget=forms.TextInput(
-                                attrs={'placeholder': extraField.initial}
+                                attrs={'placeholder': extraField.placeholder}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'FloatField':
                     self.fields[slugify(extraField.label)] = forms.FloatField(label=extraField.label,
+                            initial=extraField.initial,
                             widget=forms.TextInput(
-                                attrs={'placeholder': extraField.initial}
+                                attrs={'placeholder': extraField.placeholder}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'FileField': 
@@ -58,20 +62,23 @@ class ContactFormPlus(forms.Form):
                             required=extraField.required)
                 elif extraField.fieldType == 'IntegerField':
                     self.fields[slugify(extraField.label)] = forms.IntegerField(label=extraField.label,
+                            initial=extraField.initial,
                             widget=forms.TextInput(
-                                attrs={'placeholder': extraField.initial}
+                                attrs={'placeholder': extraField.placeholder}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'IPAddressField':
                     self.fields[slugify(extraField.label)] = forms.IPAddressField(label=extraField.label,
+                            initial=extraField.initial,
                             widget=forms.TextInput(
-                                attrs={'placeholder': extraField.initial}
+                                attrs={'placeholder': extraField.placeholder}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'auto_Textarea':
                     self.fields[slugify(extraField.label)] = forms.CharField(label=extraField.label,
+                            initial=extraField.initial,
                             widget=forms.Textarea(
-                                attrs={'placeholder': extraField.initial}
+                                attrs={'placeholder': extraField.placeholder}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'auto_hidden_input':
@@ -109,6 +116,9 @@ class ContactFormPlus(forms.Form):
                     self.fields[slugify(extraField.label)] = forms.CharField(
                         label=extraField.label,
                         initial=extraField.initial,
+                        widget=forms.Textarea(
+                            attrs={'placeholder': extraField.placeholder}
+                        ),
                         required=extraField.required,
                         validators=get_validators())
 

--- a/cmsplugin_contact_plus/forms.py
+++ b/cmsplugin_contact_plus/forms.py
@@ -23,6 +23,9 @@ class ContactFormPlus(forms.Form):
                 if extraField.fieldType == 'CharField':
                     self.fields[slugify(extraField.label)] = forms.CharField(label=extraField.label,
                             initial=extraField.initial,
+                            widget=forms.TextInput(
+                                attrs={'placeholder': extraField.initial}
+                            ),
                             required=extraField.required)
                 elif extraField.fieldType == 'BooleanField':
                     self.fields[slugify(extraField.label)] = forms.BooleanField(label=extraField.label,
@@ -31,14 +34,23 @@ class ContactFormPlus(forms.Form):
                 elif extraField.fieldType == 'EmailField':
                     self.fields[slugify(extraField.label)] = forms.EmailField(label=extraField.label,
                             initial=extraField.initial,
+                            widget=forms.TextInput(
+                                attrs={'placeholder': extraField.initial}
+                            ),
                             required=extraField.required)
                 elif extraField.fieldType == 'DecimalField':
                     self.fields[slugify(extraField.label)] = forms.DecimalField(label=extraField.label,
                             initial=extraField.initial,
+                            widget=forms.TextInput(
+                                attrs={'placeholder': extraField.initial}
+                            ),
                             required=extraField.required)
                 elif extraField.fieldType == 'FloatField':
                     self.fields[slugify(extraField.label)] = forms.FloatField(label=extraField.label,
                             initial=extraField.initial,
+                            widget=forms.TextInput(
+                                attrs={'placeholder': extraField.initial}
+                            ),
                             required=extraField.required)
                 elif extraField.fieldType == 'FileField': 
                     self.fields[slugify(extraField.label)] = forms.FileField(label=extraField.label,
@@ -51,15 +63,23 @@ class ContactFormPlus(forms.Form):
                 elif extraField.fieldType == 'IntegerField':
                     self.fields[slugify(extraField.label)] = forms.IntegerField(label=extraField.label,
                             initial=extraField.initial,
+                            widget=forms.TextInput(
+                                attrs={'placeholder': extraField.initial}
+                            ),
                             required=extraField.required)
                 elif extraField.fieldType == 'IPAddressField':
                     self.fields[slugify(extraField.label)] = forms.IPAddressField(label=extraField.label,
                             initial=extraField.initial,
+                            widget=forms.TextInput(
+                                attrs={'placeholder': extraField.initial}
+                            ),
                             required=extraField.required)
                 elif extraField.fieldType == 'auto_Textarea':
                     self.fields[slugify(extraField.label)] = forms.CharField(label=extraField.label,
                             initial=extraField.initial,
-                            widget=forms.Textarea,
+                            widget=forms.Textarea(
+                                attrs={'placeholder': extraField.initial}
+                            ),
                             required=extraField.required)
                 elif extraField.fieldType == 'auto_hidden_input':
                     self.fields[slugify(extraField.label)] = forms.CharField(label=extraField.label,

--- a/cmsplugin_contact_plus/forms.py
+++ b/cmsplugin_contact_plus/forms.py
@@ -22,7 +22,6 @@ class ContactFormPlus(forms.Form):
             for extraField in contactFormInstance.extrafield_set.all():
                 if extraField.fieldType == 'CharField':
                     self.fields[slugify(extraField.label)] = forms.CharField(label=extraField.label,
-                            initial=extraField.initial,
                             widget=forms.TextInput(
                                 attrs={'placeholder': extraField.initial}
                             ),
@@ -33,21 +32,18 @@ class ContactFormPlus(forms.Form):
                             required=extraField.required)
                 elif extraField.fieldType == 'EmailField':
                     self.fields[slugify(extraField.label)] = forms.EmailField(label=extraField.label,
-                            initial=extraField.initial,
                             widget=forms.TextInput(
                                 attrs={'placeholder': extraField.initial}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'DecimalField':
                     self.fields[slugify(extraField.label)] = forms.DecimalField(label=extraField.label,
-                            initial=extraField.initial,
                             widget=forms.TextInput(
                                 attrs={'placeholder': extraField.initial}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'FloatField':
                     self.fields[slugify(extraField.label)] = forms.FloatField(label=extraField.label,
-                            initial=extraField.initial,
                             widget=forms.TextInput(
                                 attrs={'placeholder': extraField.initial}
                             ),
@@ -62,21 +58,18 @@ class ContactFormPlus(forms.Form):
                             required=extraField.required)
                 elif extraField.fieldType == 'IntegerField':
                     self.fields[slugify(extraField.label)] = forms.IntegerField(label=extraField.label,
-                            initial=extraField.initial,
                             widget=forms.TextInput(
                                 attrs={'placeholder': extraField.initial}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'IPAddressField':
                     self.fields[slugify(extraField.label)] = forms.IPAddressField(label=extraField.label,
-                            initial=extraField.initial,
                             widget=forms.TextInput(
                                 attrs={'placeholder': extraField.initial}
                             ),
                             required=extraField.required)
                 elif extraField.fieldType == 'auto_Textarea':
                     self.fields[slugify(extraField.label)] = forms.CharField(label=extraField.label,
-                            initial=extraField.initial,
                             widget=forms.Textarea(
                                 attrs={'placeholder': extraField.initial}
                             ),

--- a/cmsplugin_contact_plus/migrations/0004_auto_20170410_1553.py
+++ b/cmsplugin_contact_plus/migrations/0004_auto_20170410_1553.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_contact_plus', '0003_auto_20161102_1927'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='extrafield',
+            name='placeholder',
+            field=models.CharField(max_length=250, null=True, verbose_name='Placeholder Value', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='contactplus',
+            name='recipient_email',
+            field=models.EmailField(default=b'', max_length=254, verbose_name='Email of recipients'),
+        ),
+    ]

--- a/cmsplugin_contact_plus/models.py
+++ b/cmsplugin_contact_plus/models.py
@@ -99,6 +99,9 @@ class ExtraField(SortableMixin):
     fieldType = models.CharField(max_length=100, choices=FIELD_TYPE)
     initial = models.CharField(
         _('Inital Value'), max_length=250, blank=True, null=True)
+    placeholder = models.CharField(
+        _('Placeholder Value'), max_length=250, blank=True, null=True)
+    )
     required = models.BooleanField(
         _('Mandatory field'), default=True)
     widget = models.CharField(

--- a/cmsplugin_contact_plus/models.py
+++ b/cmsplugin_contact_plus/models.py
@@ -101,7 +101,6 @@ class ExtraField(SortableMixin):
         _('Inital Value'), max_length=250, blank=True, null=True)
     placeholder = models.CharField(
         _('Placeholder Value'), max_length=250, blank=True, null=True)
-    )
     required = models.BooleanField(
         _('Mandatory field'), default=True)
     widget = models.CharField(


### PR DESCRIPTION
Add placeholder attribute for inputs.

Sometimes it is more useful to have placeholder attribute, instead of initial value, because it is cleared automatically on value change, and it acts as a short hint that describes the expected value of an <input> element.

IE 10 and higher supports this feature.

[More info on this attribute.](https://www.w3schools.com/tags/att_input_placeholder.asp)